### PR TITLE
add a basic, short README in English

### DIFF
--- a/README-en.rst
+++ b/README-en.rst
@@ -1,0 +1,54 @@
+What is MultiGeiger?
+--------------------
+
+The MultiGeiger is a radioactivity measurement device.
+
+Main features
+~~~~~~~~~~~~~
+
+**multiple use cases supported**
+
+ * fixed location stations (data transfer via network)
+ * mobile operations (using the OLED display and speaker)
+ * (more are planned)
+
+**multiple 400V Geiger-Mueller tubes supported**
+
+ * big, sensitive tubes, like the Si21g or Si22g (for measurement stations)
+ * smaller, less sensitive tubes, like the SBM21 (good for finding hot spots)
+
+**Hardware**
+
+ * low parts count, simple to assemble
+ * inexpensive, but still good parts
+ * using ESP32, a modern and fast 32bit micro controller
+ * with WiFi (WPA2) or with WiFi + LoRA
+ * with OLED display
+
+**Firmware**
+
+ * implemented in C
+ * using the popular arduino API
+ * over-the-air firmware updates
+
+**Network and Community**
+
+ * this is an Ecocurious citizen science project
+ * web-based geo map for publishing measurements
+ * web-based archive of historic radiation data
+
+**Free and Open**
+
+ * GPL v3 licensed
+ * open development and issue tracking on GitHub
+
+
+There is a lot more information in our `documentation`_, which is also available as `offline documentation`_.
+
+.. _documentation: https://multigeiger.readthedocs.org/
+.. _offline documentation: https://readthedocs.org/projects/multigeiger/downloads
+
+
+Note: some stuff is only available in German language or in document formats which
+can not be directly included in the above mentioned docs - see the docs/ directory.
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,8 @@
 MultiGeiger Documentation
 =========================
 
+.. include:: ../../README-en.rst
+
 .. toctree::
    :maxdepth: 2
 


### PR DESCRIPTION
this is about how a project README should look like, IMHO.

it should contain enough information for the reader to decide whether
this is the project they searched for.

but it should not be TL;DR (== too long; didn't read).

thus, it should NOT contain detailled installation and configuration
docs (that stuff belongs into the extensive docs the README links to).

this README has 2 uses / functions:
- being included as introduction into the long readthedocs.io based docs
- being shown on github (after review / community decision)

this avoids duplication and eases future changes/updates.