### PR TITLE
new log(level, format, ...) function, fixes #161

### DIFF
--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -70,6 +70,13 @@
 // STICK -> Heltec Wireless Stick (has LoRa on board)
 #define STICK 2
 
+// log levels
+#define DEBUG 0
+#define INFO 1
+#define WARNING 2
+#define ERROR 3
+#define CRITICAL 4
+#define NOLOG 999  // only to set log_level, so log() never creates output
 
 // Includes
 //====================================================================================================================================
@@ -294,12 +301,7 @@ void IRAM_ATTR isr_GMC_count() {
 //====================================================================================================================================
 // Logging
 
-#define DEBUG 0
-#define INFO 1
-#define WARNING 2
-#define ERROR 3
-
-int log_level = DEBUG;  // messages at level >= log_level will be output
+int log_level = DEFAULT_LOG_LEVEL;  // messages at level >= log_level will be output
 
 // this is to differentiate our output from other esp32 output (e.g. wifi messages)
 #define LOG_PREFIX "GEIGER: "

--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -316,8 +316,8 @@ void log(int level, const char *format, ...) {
   char buf[vsnprintf(NULL, 0, format, args) + 1 + LOG_PREFIX_LEN];
   strcpy(buf, LOG_PREFIX);
   vsprintf(buf + LOG_PREFIX_LEN, format, args);
-  Serial.println(buf);
   va_end(args);
+  Serial.println(buf);
 }
 
 

--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -301,15 +301,19 @@ void IRAM_ATTR isr_GMC_count() {
 
 int log_level = DEBUG;  // messages at level >= log_level will be output
 
+// this is to differentiate our output from other esp32 output (e.g. wifi messages)
+#define LOG_PREFIX "GEIGER: "
+#define LOG_PREFIX_LEN 8  // 8 chars, without the terminating \0
+
 void log(int level, const char *format, ...) {
   if (level < log_level)
     return;
 
   va_list args;
   va_start(args, format);
-  char buf[vsnprintf(NULL, 0, format, args) + 1];
-  vsprintf(buf, format, args);
-  Serial.print("GEIGER: ");  // this is to differentiate our output from other esp32 output (e.g. wifi messages)
+  char buf[vsnprintf(NULL, 0, format, args) + 1 + LOG_PREFIX_LEN];
+  strcpy(buf, LOG_PREFIX);
+  vsprintf(buf + LOG_PREFIX_LEN, format, args);
   Serial.println(buf);
   va_end(args);
 }

--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -743,7 +743,7 @@ int gen_charge_pulses(int max_charge_pulses) {
   } while ((charge_pulses < max_charge_pulses) && !isr_GMC_cap_full); // either a timeout or a capacitor full interrupt stops this loop
   time2hvpulse = millis();                              // we just pulsed, so restart timer
   if ((charge_pulses == max_charge_pulses) && !isr_GMC_cap_full)
-    log(ERROR, "HV charging failed!");                  // pulsed a lot, but still the capacitor is not at desired voltage
+    log(CRITICAL, "HV charging failed!");               // pulsed a lot, but still the capacitor is not at desired voltage
   return charge_pulses;
 }
 

--- a/multigeiger/userdefines-example.h
+++ b/multigeiger/userdefines-example.h
@@ -19,6 +19,10 @@
 // #define TUBE_TYPE SBM19
 #define TUBE_TYPE Si22G
 
+// set the log_level that determines how much log output one gets on Serial/USB
+// DEBUG, INFO, WARNING, ERROR, CRITICAL, NOLOG
+#define DEFAULT_LOG_LEVEL DEBUG
+
 // ** select (uncomment) exactly one kind of debug level output to serial io (USB)
 // #define   SERIAL_DEBUG Serial_None            // No Serial Printout
 // #define   SERIAL_DEBUG Serial_Debug           // Only debug and error output


### PR DESCRIPTION
- printf-style call
- only outputs for level >= log_level
- levels: DEBUG, INFO, WARNING, ERROR, CRITICAL, NOLOG
- internally prepends "GEIGER: " to differentiate our output from other
- adds correct line endings by using Serial.println()

not tested yet.