### PR TITLE
Use webpage to to set configuration, fixes #140

### DIFF
--- a/multigeiger/display.cpp
+++ b/multigeiger/display.cpp
@@ -98,11 +98,13 @@ char *nullFill(int n, int digits) {
 }
 
 void DisplayGMC(int TimeSec, int RadNSvph, int CPS, bool use_display, bool connected) {
-  if (!use_display && !displayIsClear) {
-    u8x8.clear();
-    clearDisplayLine(4);
-    clearDisplayLine(5);
-    displayIsClear = true;
+  if (!use_display) {
+    if (!displayIsClear) {
+      u8x8.clear();
+      clearDisplayLine(4);
+      clearDisplayLine(5);
+      displayIsClear = true;
+    }
     return;
   }
 

--- a/multigeiger/loraWan.cpp
+++ b/multigeiger/loraWan.cpp
@@ -19,6 +19,8 @@
 // DIO2 (10) = GPIO32 (12)
 
 #include "userdefines.h"
+#include "webconf.h"
+#include "utils.h";
 
 // Send a valid LoRaWAN packet using frequency and encryption settings matching
 // those of the The Things Network.
@@ -282,39 +284,6 @@ transmissionStatus_t lorawan_send(uint8_t txPort, uint8_t *txBuffer, uint8_t txS
       }
     }
   }
-}
-
-//convert hexstring to len bytes of data
-//returns 0 on success, -1 on error
-//data is a buffer of at least len bytes
-//hexstring is upper or lower case hexadecimal, NOT prepended with "0x"
-int hex2data(unsigned char *data, const char *hexstring, unsigned int len, bool reverse) {
-  const char *pos = hexstring;
-  char *endptr;
-  size_t count = 0;
-  if ((hexstring[0] == '\0') || (strlen(hexstring) % 2)) {
-    //hexstring contains no data
-    //or hexstring has an odd length
-    return -1;
-  }
-  for (count = 0; count < len; count++) {
-    char buf[5] = {'0', 'x', pos[0], pos[1], 0};
-    data[count] = strtol(buf, &endptr, 0);
-    pos += 2 * sizeof(char);
-    if (endptr[0] != '\0') {
-      //non-hexadecimal character encountered
-      return -1;
-    }
-  }
-  if (reverse) {
-    char temp;
-    for (int i = 0; i < len / 2; i++) {
-      temp = data[i];
-      data[i] = data[len - i - 1];
-      data[len - i - 1] = temp;
-    }
-  }
-  return 0;
 }
 
 #endif

--- a/multigeiger/loraWan.cpp
+++ b/multigeiger/loraWan.cpp
@@ -1,3 +1,6 @@
+// to have CPU defined:
+#include "userdefines.h"
+
 // Compile this only if we have a LoRa capable hardware
 #if CPU==STICK
 
@@ -17,10 +20,6 @@
 // DIO0 (8) = GPIO26 (15)
 // DIO1 (9) = GPIO33 (13)
 // DIO2 (10) = GPIO32 (12)
-
-#include "userdefines.h"
-#include "webconf.h"
-#include "utils.h";
 
 // Send a valid LoRaWAN packet using frequency and encryption settings matching
 // those of the The Things Network.
@@ -47,12 +46,9 @@
 #include "hal/heltecv2.h"
 #include <SPI.h>
 #include "webconf.h"
-
+#include "utils.h"
 #include "loraWan.h"
 #include "log.h"
-
-// Prototype
-int hex2data(unsigned char *data, const char *hexstring, unsigned int len, bool reverse);
 
 // For normal use, we require that you edit the sketch to replace FILLMEIN
 // with values assigned by the TTN console. However, for regression tests,
@@ -70,15 +66,17 @@ int hex2data(unsigned char *data, const char *hexstring, unsigned int len, bool 
 // All these 3 LoRa parameters (DEVEUI, APPEUI and APPKEY) may be copied literally from the TTN console window.
 // The necessary reversal on DEVEUI and APPEUI is done by hex2data.
 void os_getArtEui(u1_t *buf) {
-  (void) hex2data(buf, (const char *) appeui, 8, true);
+  (void) hex2data(buf, (const char *) appeui, 8);
+  reverseByteArray(buf, 8);
 }
 
 void os_getDevEui(u1_t *buf) {
-  (void) hex2data(buf, (const char *) deveui, 8, true);
+  (void) hex2data(buf, (const char *) deveui, 8);
+  reverseByteArray(buf, 8);
 }
 
 void os_getDevKey(u1_t *buf) {
-  (void) hex2data(buf, (const char *) appkey, 16, false);
+  (void) hex2data(buf, (const char *) appkey, 16);
 }
 
 static osjob_t sendjob;

--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -66,7 +66,7 @@ void setup() {
   setup_webconf();
   setup_transmission(VERSION_STR, ssid);
 
-  if (parameterTrue(startSound))
+  if (playSound)
     play_start_sound();
 
   setup_log_data(SERIAL_DEBUG);
@@ -140,7 +140,7 @@ void loop() {
 
     // ... and display them.
     DisplayGMC(((int)accumulated_time / 1000), (int)(accumulated_Dose_Rate * 1000), (int)(Count_Rate * 60),
-               (parameterTrue(showDisplay) && switches.display_on), wifi_connected);
+               (showDisplay && switches.display_on), wifi_connected);
 
     if (Serial_Print_Mode == Serial_Logging) {
       log_data(GMC_counts, dt, Count_Rate, Dose_Rate, HV_pulse_count,
@@ -175,7 +175,7 @@ void loop() {
   if (afterStartTime && ((current_ms - boot_timestamp) >= afterStartTime)) {
     afterStartTime = 0;
     DisplayGMC(((int)accumulated_time / 1000), (int)(accumulated_Dose_Rate * 1000), (int)(Count_Rate * 60),
-               (parameterTrue(showDisplay) && switches.display_on), wifi_connected);
+               (showDisplay && switches.display_on), wifi_connected);
   }
 
   // Check, if we have to send to sensor.community etc.
@@ -207,7 +207,7 @@ void loop() {
 
   static unsigned int last_GMC_counts = 0;
   if (GMC_counts != last_GMC_counts) {
-    tick(parameterTrue(ledTick) && switches.led_on, parameterTrue(speakerTick) && switches.speaker_on);
+    tick(ledTick && switches.led_on, speakerTick && switches.speaker_on);
     last_GMC_counts = GMC_counts;
   }
 

--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -66,7 +66,7 @@ void setup() {
   setup_webconf();
   setup_transmission(VERSION_STR, ssid);
 
-  if (PLAY_SOUND)
+  if (parameterTrue(startSound))
     play_start_sound();
 
   setup_log_data(SERIAL_DEBUG);
@@ -140,7 +140,7 @@ void loop() {
 
     // ... and display them.
     DisplayGMC(((int)accumulated_time / 1000), (int)(accumulated_Dose_Rate * 1000), (int)(Count_Rate * 60),
-               (SHOW_DISPLAY && switches.display_on), wifi_connected);
+               (parameterTrue(showDisplay) && switches.display_on), wifi_connected);
 
     if (Serial_Print_Mode == Serial_Logging) {
       log_data(GMC_counts, dt, Count_Rate, Dose_Rate, HV_pulse_count,
@@ -175,7 +175,7 @@ void loop() {
   if (afterStartTime && ((current_ms - boot_timestamp) >= afterStartTime)) {
     afterStartTime = 0;
     DisplayGMC(((int)accumulated_time / 1000), (int)(accumulated_Dose_Rate * 1000), (int)(Count_Rate * 60),
-               (SHOW_DISPLAY && switches.display_on), wifi_connected);
+               (parameterTrue(showDisplay) && switches.display_on), wifi_connected);
   }
 
   // Check, if we have to send to sensor.community etc.
@@ -207,7 +207,7 @@ void loop() {
 
   static unsigned int last_GMC_counts = 0;
   if (GMC_counts != last_GMC_counts) {
-    tick(LED_TICK && switches.led_on, SPEAKER_TICK && switches.speaker_on);
+    tick(parameterTrue(ledTick) && switches.led_on, parameterTrue(speakerTick) && switches.speaker_on);
     last_GMC_counts = GMC_counts;
   }
 

--- a/multigeiger/transmission.cpp
+++ b/multigeiger/transmission.cpp
@@ -216,7 +216,7 @@ void transmit_data(String tube_type, int tube_nbr, unsigned int dt, unsigned int
   delay(300);
   #endif
 
-  if(parameterTrue(sendToMadavi)) {
+  if(sendToMadavi) {
     log(INFO, "Sending to Madavi ...");
     displayStatusLine("Madavi");
     send_http_geiger_2_madavi(tube_type, dt, hv_pulses, gm_counts, cpm);
@@ -226,7 +226,7 @@ void transmit_data(String tube_type, int tube_nbr, unsigned int dt, unsigned int
     delay(300);
   }
 
-  if(parameterTrue(sendToCommunity)) {
+  if(sendToCommunity) {
     log(INFO, "Sending to sensor.community ...");
     displayStatusLine("sensor.community");
     send_http_geiger(SENSORCOMMUNITY, dt, hv_pulses, gm_counts, cpm, XPIN_RADIATION)  ;
@@ -237,7 +237,7 @@ void transmit_data(String tube_type, int tube_nbr, unsigned int dt, unsigned int
   }
 
   #if CPU==STICK
-  if(parameterTrue(sendToLora) && (strcmp(appeui,"") != 0)) { // send only, if we have LoRa credentials
+  if(sendToLora && (strcmp(appeui,"") != 0)) { // send only, if we have LoRa credentials
     log(INFO, "Sending to TTN ...");
     displayStatusLine("TTN");
     send_ttn_geiger(tube_nbr, dt, gm_counts);

--- a/multigeiger/transmission.cpp
+++ b/multigeiger/transmission.cpp
@@ -237,7 +237,7 @@ void transmit_data(String tube_type, int tube_nbr, unsigned int dt, unsigned int
   }
 
   #if CPU==STICK
-  if(sendToLora && (strcmp(appeui,"") != 0)) { // send only, if we have LoRa credentials
+  if(sendToLora && (strcmp(appeui, "") != 0)) {    // send only, if we have LoRa credentials
     log(INFO, "Sending to TTN ...");
     displayStatusLine("TTN");
     send_ttn_geiger(tube_nbr, dt, gm_counts);

--- a/multigeiger/transmission.cpp
+++ b/multigeiger/transmission.cpp
@@ -229,7 +229,7 @@ void transmit_data(String tube_type, int tube_nbr, unsigned int dt, unsigned int
   if(sendToCommunity) {
     log(INFO, "Sending to sensor.community ...");
     displayStatusLine("sensor.community");
-    send_http_geiger(SENSORCOMMUNITY, dt, hv_pulses, gm_counts, cpm, XPIN_RADIATION)  ;
+    send_http_geiger(SENSORCOMMUNITY, dt, hv_pulses, gm_counts, cpm, XPIN_RADIATION);
     if (have_thp) {
       send_http_thp(SENSORCOMMUNITY, temperature, humidity, pressure, XPIN_BME280);
     }

--- a/multigeiger/transmission.cpp
+++ b/multigeiger/transmission.cpp
@@ -8,14 +8,9 @@
 #include "log.h"
 #include "display.h"
 #include "userdefines.h"
+#include "webconf.h"
 
-// Check if a CPU (board) with LoRa is selected. If not, deactivate SEND2LORA.
-#if !((CPU==LORA) || (CPU==STICK))
-#undef SEND2LORA
-#define SEND2LORA 0
-#endif
-
-#if SEND2LORA==1
+#if CPU==STICK
 #include "loraWan.h"
 #endif
 
@@ -27,7 +22,7 @@
 #define TOILET "http://ptsv2.com/t/rk9pr-1582220446/post"
 
 static String http_software_version;
-#if SEND2LORA
+#if CPU==STICK
 static unsigned int lora_software_version;
 #endif
 static String chipID;
@@ -38,7 +33,7 @@ void setup_transmission(const char *version, char *ssid) {
 
   http_software_version = String(version);
 
-  #if SEND2LORA
+  #if CPU==STICK
   int major, minor, patch;
   sscanf(version, "V%d.%d.%d", &major, &minor, &patch);
   lora_software_version = (major << 12) + (minor << 4) + patch;
@@ -172,7 +167,7 @@ void send_http_thp_2_madavi(float temperature, float humidity, float pressure) {
   send_http(&http, body);
 }
 
-#if SEND2LORA
+#if CPU==STICK
 // LoRa payload:
 // To minimise airtime and follow the 'TTN Fair Access Policy', we only send necessary bytes.
 // We do NOT use Cayenne LPP.
@@ -221,32 +216,34 @@ void transmit_data(String tube_type, int tube_nbr, unsigned int dt, unsigned int
   delay(300);
   #endif
 
-  #if SEND2MADAVI
-  log(INFO, "Sending to Madavi ...");
-  displayStatusLine("Madavi");
-  send_http_geiger_2_madavi(tube_type, dt, hv_pulses, gm_counts, cpm);
-  if (have_thp) {
-    send_http_thp_2_madavi(temperature, humidity, pressure);
+  if(parameterTrue(sendToMadavi)) {
+    log(INFO, "Sending to Madavi ...");
+    displayStatusLine("Madavi");
+    send_http_geiger_2_madavi(tube_type, dt, hv_pulses, gm_counts, cpm);
+    if (have_thp) {
+      send_http_thp_2_madavi(temperature, humidity, pressure);
+    }
+    delay(300);
   }
-  delay(300);
-  #endif
 
-  #if SEND2SENSORCOMMUNITY
-  log(INFO, "Sending to sensor.community ...");
-  displayStatusLine("sensor.community");
-  send_http_geiger(SENSORCOMMUNITY, dt, hv_pulses, gm_counts, cpm, XPIN_RADIATION);
-  if (have_thp) {
-    send_http_thp(SENSORCOMMUNITY, temperature, humidity, pressure, XPIN_BME280);
+  if(parameterTrue(sendToCommunity)) {
+    log(INFO, "Sending to sensor.community ...");
+    displayStatusLine("sensor.community");
+    send_http_geiger(SENSORCOMMUNITY, dt, hv_pulses, gm_counts, cpm, XPIN_RADIATION)  ;
+    if (have_thp) {
+      send_http_thp(SENSORCOMMUNITY, temperature, humidity, pressure, XPIN_BME280);
+    }
+    delay(300);
   }
-  delay(300);
-  #endif
 
-  #if SEND2LORA
-  log(INFO, "Sending to TTN ...");
-  displayStatusLine("TTN");
-  send_ttn_geiger(tube_nbr, dt, gm_counts);
-  if (have_thp)
-    send_ttn_thp(temperature, humidity, pressure);
+  #if CPU==STICK
+  if(parameterTrue(sendToLora) && (strcmp(appeui,"") != 0)) { // send only, if we have LoRa credentials
+    log(INFO, "Sending to TTN ...");
+    displayStatusLine("TTN");
+    send_ttn_geiger(tube_nbr, dt, gm_counts);
+    if (have_thp)
+      send_ttn_thp(temperature, humidity, pressure);
+  }
   #endif
 
   displayStatusLine(" ");

--- a/multigeiger/userdefines-example.h
+++ b/multigeiger/userdefines-example.h
@@ -46,31 +46,3 @@
 
 // Time for configuration via local access point [sec]
 #define WAIT_4_CONFIG 180
-
-// Speaker Ticks with every pulse?  1-> on,  0-> off
-#define SPEAKER_TICK 1
-
-// White LED on uC board flashing with every pulse?
-#define LED_TICK  1
-
-// Enable display?
-#define SHOW_DISPLAY 1
-
-// Play a start sound at boot/reboot time?
-#define PLAY_SOUND 1
-
-// Send to servers:
-// Send data to Madavi server?
-// Madavi should be used to see values in real time.
-#define SEND2MADAVI 1
-
-// Send data to sensor.community server?
-// Should always be 1 so that the data is archived there. Standard server for devices without LoRa.
-#define SEND2SENSORCOMMUNITY 1
-
-// Send data via LoRa to TTN?
-// Only for devices with LoRa, automatically deactivated for devices without LoRa.
-// If this is set to 1, sending to Madavi and sensor.community should be deactivated!
-// Note: The TTN configuration needs to be done in lorawan.cpp (starting at line 65).
-#define SEND2LORA 0
-

--- a/multigeiger/userdefines-example.h
+++ b/multigeiger/userdefines-example.h
@@ -46,3 +46,31 @@
 
 // Time for configuration via local access point [sec]
 #define WAIT_4_CONFIG 180
+
+// Speaker Ticks with every pulse?  1-> on,  0-> off
+#define SPEAKER_TICK 1
+
+// White LED on uC board flashing with every pulse?
+#define LED_TICK  1
+
+// Enable display?
+#define SHOW_DISPLAY 1
+
+// Play a start sound at boot/reboot time?
+#define PLAY_SOUND 1
+
+// Send to servers:
+// Send data to Madavi server?
+// Madavi should be used to see values in real time.
+#define SEND2MADAVI 1
+
+// Send data to sensor.community server?
+// Should always be 1 so that the data is archived there. Standard server for devices without LoRa.
+#define SEND2SENSORCOMMUNITY 1
+
+// Send data via LoRa to TTN?
+// Only for devices with LoRa, automatically deactivated for devices without LoRa.
+// If this is set to 1, sending to Madavi and sensor.community should be deactivated!
+// Note: The TTN configuration needs to be done in lorawan.cpp (starting at line 65).
+#define SEND2LORA 0
+

--- a/multigeiger/utils.cpp
+++ b/multigeiger/utils.cpp
@@ -1,4 +1,4 @@
-// Div utilities
+// Misc. utilities
 
 #include <Arduino.h>
 
@@ -6,14 +6,14 @@
 #include "utils.h"
 
 // ** convert hexstring to len bytes of data
-//returns 0 on success, -1 on error
-//data is a buffer of at least len bytes
-//hexstring is upper or lower case hexadecimal, NOT prepended with "0x"
-//convert hexstring to len bytes of data
-//returns 0 on success, -1 on error
-//data is a buffer of at least len bytes
-//hexstring is upper or lower case hexadecimal, NOT prepended with "0x"
-int hex2data(unsigned char *data, const char *hexstring, unsigned int len, bool reverse) {
+// returns 0 on success, -1 on error
+// data is a buffer of at least len bytes
+// hexstring is upper or lower case hexadecimal, NOT prepended with "0x"
+// convert hexstring to len bytes of data
+// returns 0 on success, -1 on error
+// data is a buffer of at least len bytes
+// hexstring is upper or lower case hexadecimal, NOT prepended with "0x"
+int hex2data(unsigned char *data, const char *hexstring, unsigned int len) {
   const char *pos = hexstring;
   char *endptr;
   size_t count = 0;
@@ -31,13 +31,10 @@ int hex2data(unsigned char *data, const char *hexstring, unsigned int len, bool 
       return -1;
     }
   }
-  if (reverse) {
-    reverseByteArray(data, len);
-  }
   return 0;
 }
 
-// reverse a bytearray of length len
+// reverse a bytearray of even length len
 void reverseByteArray(unsigned char *data, int len) {
   char temp;
   for (int i = 0; i < len / 2; i++) {

--- a/multigeiger/utils.cpp
+++ b/multigeiger/utils.cpp
@@ -1,0 +1,49 @@
+// Div utilities
+
+#include <Arduino.h>
+
+#include "log.h"
+#include "utils.h"
+
+// ** convert hexstring to len bytes of data
+//returns 0 on success, -1 on error
+//data is a buffer of at least len bytes
+//hexstring is upper or lower case hexadecimal, NOT prepended with "0x"
+//convert hexstring to len bytes of data
+//returns 0 on success, -1 on error
+//data is a buffer of at least len bytes
+//hexstring is upper or lower case hexadecimal, NOT prepended with "0x"
+int hex2data(unsigned char *data, const char *hexstring, unsigned int len, bool reverse) {
+  const char *pos = hexstring;
+  char *endptr;
+  size_t count = 0;
+  if ((hexstring[0] == '\0') || (strlen(hexstring) % 2)) {
+    //hexstring contains no data
+    //or hexstring has an odd length
+    return -1;
+  }
+  for (count = 0; count < len; count++) {
+    char buf[5] = {'0', 'x', pos[0], pos[1], 0};
+    data[count] = strtol(buf, &endptr, 0);
+    pos += 2 * sizeof(char);
+    if (endptr[0] != '\0') {
+      //non-hexadecimal character encountered
+      return -1;
+    }
+  }
+  if (reverse) {
+    reverseByteArray(data, len);
+  }
+  return 0;
+}
+
+// reverse a bytearray of length len
+void reverseByteArray(unsigned char *data, int len) {
+  char temp;
+  for (int i = 0; i < len / 2; i++) {
+    temp = data[i];
+    data[i] = data[len - i - 1];
+    data[len - i - 1] = temp;
+  }
+}
+

--- a/multigeiger/utils.cpp
+++ b/multigeiger/utils.cpp
@@ -18,8 +18,8 @@ int hex2data(unsigned char *data, const char *hexstring, unsigned int len) {
   char *endptr;
   size_t count = 0;
   if ((hexstring[0] == '\0') || (strlen(hexstring) % 2)) {
-    //hexstring contains no data
-    //or hexstring has an odd length
+    // hexstring contains no data
+    // or hexstring has an odd length
     return -1;
   }
   for (count = 0; count < len; count++) {
@@ -27,7 +27,7 @@ int hex2data(unsigned char *data, const char *hexstring, unsigned int len) {
     data[count] = strtol(buf, &endptr, 0);
     pos += 2 * sizeof(char);
     if (endptr[0] != '\0') {
-      //non-hexadecimal character encountered
+      // non-hexadecimal character encountered
       return -1;
     }
   }

--- a/multigeiger/utils.h
+++ b/multigeiger/utils.h
@@ -1,11 +1,10 @@
-// Div. utilities
+// Misc. utilities
 
 #ifndef UTILS_H
 #define UTILS_H
 
 // Prototypes
-int hex2data(unsigned char *data, const char *hexstring, unsigned int len, bool reverse);
+int hex2data(unsigned char *data, const char *hexstring, unsigned int len);
 void reverseByteArray(unsigned char *data, int len);
-
 
 #endif

--- a/multigeiger/utils.h
+++ b/multigeiger/utils.h
@@ -1,0 +1,11 @@
+// Div. utilities
+
+#ifndef UTILS_H
+#define UTILS_H
+
+// Prototypes
+int hex2data(unsigned char *data, const char *hexstring, unsigned int len, bool reverse);
+void reverseByteArray(unsigned char *data, int len);
+
+
+#endif

--- a/multigeiger/webconf.cpp
+++ b/multigeiger/webconf.cpp
@@ -5,8 +5,47 @@
 
 #include "IotWebConf.h"
 #include <HTTPClient.h>
+#include "userdefines.h"
 
-#define CONFIG_VERSION "012"  // for IoTWebConfig
+// All these flags are ON (=1) at startup
+// They all can be changed at any time using the web interface
+char speakerTick[2] = "1";
+char startSound[2] = "1";
+char ledTick[2] = "1";
+char showDisplay[2] = "1";
+#if CPU==STICK
+// this is LoRa hardware: don't send to WiFi servers by default
+char sendToCommunity[2] = "0";
+char sendToMadavi[2] = "0";
+// send to LoRa by default
+char sendToLora[2] = "1";
+char appeui[17] = "";
+char deveui[17] = "";
+char appkey[IOTWEBCONF_WORD_LEN] = "";
+#else
+// WiFi hardware: send to wifi servers and not to LoRa
+char sendToLora[2] = "0";
+char sendToCommunity[2] = "1";
+char sendToMadavi[2] = "1";
+#endif
+
+IotWebConfSeparator sep0 = IotWebConfSeparator("Tick settings");
+IotWebConfParameter startSoundParam = IotWebConfParameter("Start sound (1=ON)", "startSound", startSound, 2, "number", "0/1", NULL, "min='0' max='1' step='1'");
+IotWebConfParameter speakerTickParam = IotWebConfParameter("Speaker tick (1=ON)", "speakerTick", speakerTick, 2, "number", "0/1", NULL, "min='0' max='1' step='1'");
+IotWebConfParameter ledTickParam = IotWebConfParameter("LED ticker (1=ON)", "ledTick", ledTick, 2, "number", "0/1", NULL, "min='0' max='1' step='1'");
+IotWebConfParameter showDisplayParam = IotWebConfParameter("Show display (1=ON)", "showDisplay", showDisplay, 2, "number", "0/1", NULL, "min='0' max='1' step='1'");
+IotWebConfSeparator sep1 = IotWebConfSeparator("Server settings");
+IotWebConfParameter sendToCommunityParam = IotWebConfParameter("Send to sensors.community (1=ON)", "send2Community", sendToCommunity, 2, "number", "0/1", NULL, "min='0' max='1' step='1'");
+IotWebConfParameter sendToMadaviParam = IotWebConfParameter("Send to madavi.de (1=ON)", "send2Madavi", sendToMadavi, 2, "number", "0/1", NULL, "min='0' max='1' step='1'");
+#if CPU==STICK
+IotWebConfSeparator sep3 = IotWebConfSeparator("LoRa settings");
+IotWebConfParameter sendToLoraParam = IotWebConfParameter("Send to LoRa (=>TTN) (1=ON)", "send2lora", sendToLora, 2, "number", "0/1", NULL, "min='0' max='1' step='1'");
+IotWebConfParameter appeuiParam = IotWebConfParameter("APPEUI", "appeui", appeui, 17);
+IotWebConfParameter deveuiParam = IotWebConfParameter("DEVEUI", "deveui", deveui, 17);
+IotWebConfParameter appkeyParam = IotWebConfParameter("APPKEY", "appkey", appkey, 33);
+#endif
+
+#define CONFIG_VERSION "013"  // for IoTWebConfig
 
 DNSServer dnsServer;
 WebServer server(80);
@@ -67,7 +106,8 @@ void handleRoot(void) {  // Handle web requests to "/" path.
 }
 
 void configSaved(void) {
-  log(INFO, "Config saved");
+  log(INFO, "Config saved .. restarting");
+  ESP.restart();
 }
 
 void setup_webconf() {
@@ -80,6 +120,25 @@ void setup_webconf() {
   iotWebConf.getWifiSsidParameter()->label = "WiFi client SSID";
   iotWebConf.getWifiPasswordParameter()->label = "WiFi client password";
 
+  // add the setting parameter
+  iotWebConf.addParameter(&sep0);
+  //iotWebConf.addParameter(&startSoundParam1);
+  iotWebConf.addParameter(&startSoundParam);
+  iotWebConf.addParameter(&speakerTickParam);
+  iotWebConf.addParameter(&ledTickParam);
+  iotWebConf.addParameter(&showDisplayParam);
+  iotWebConf.addParameter(&sep1);
+  iotWebConf.addParameter(&sendToCommunityParam);
+  iotWebConf.addParameter(&sendToMadaviParam);
+  #if CPU==STICK
+  iotWebConf.addParameter(&sep3);
+  iotWebConf.addParameter(&sendToLoraParam);
+  iotWebConf.addParameter(&appeuiParam);
+  iotWebConf.addParameter(&deveuiParam);
+  iotWebConf.addParameter(&appkeyParam);
+  #endif
+
+
   iotWebConf.init();
 
   // -- Set up required URL handlers on the web server.
@@ -89,4 +148,12 @@ void setup_webconf() {
     iotWebConf.handleNotFound();
   });
 }
+
+// Check value of settings parameters
+boolean parameterTrue(char *parameter) {
+  return (strcmp(parameter, "1") == 0);
+}
+
+
+
 

--- a/multigeiger/webconf.cpp
+++ b/multigeiger/webconf.cpp
@@ -32,7 +32,7 @@ char sendToMadavi[2] = "1";
 IotWebConfSeparator sep0 = IotWebConfSeparator("Tick settings");
 IotWebConfParameter startSoundParam = IotWebConfParameter("Start sound (1=ON)", "startSound", startSound, 2, "number", "0/1", NULL, "min='0' max='1' step='1'");
 IotWebConfParameter speakerTickParam = IotWebConfParameter("Speaker tick (1=ON)", "speakerTick", speakerTick, 2, "number", "0/1", NULL, "min='0' max='1' step='1'");
-IotWebConfParameter ledTickParam = IotWebConfParameter("LED ticker (1=ON)", "ledTick", ledTick, 2, "number", "0/1", NULL, "min='0' max='1' step='1'");
+IotWebConfParameter ledTickParam = IotWebConfParameter("LED tick (1=ON)", "ledTick", ledTick, 2, "number", "0/1", NULL, "min='0' max='1' step='1'");
 IotWebConfParameter showDisplayParam = IotWebConfParameter("Show display (1=ON)", "showDisplay", showDisplay, 2, "number", "0/1", NULL, "min='0' max='1' step='1'");
 IotWebConfSeparator sep1 = IotWebConfSeparator("Server settings");
 IotWebConfParameter sendToCommunityParam = IotWebConfParameter("Send to sensors.community (1=ON)", "send2Community", sendToCommunity, 2, "number", "0/1", NULL, "min='0' max='1' step='1'");
@@ -122,7 +122,6 @@ void setup_webconf() {
 
   // add the setting parameter
   iotWebConf.addParameter(&sep0);
-  //iotWebConf.addParameter(&startSoundParam1);
   iotWebConf.addParameter(&startSoundParam);
   iotWebConf.addParameter(&speakerTickParam);
   iotWebConf.addParameter(&ledTickParam);

--- a/multigeiger/webconf.cpp
+++ b/multigeiger/webconf.cpp
@@ -184,7 +184,3 @@ void setup_webconf() {
     iotWebConf.handleNotFound();
   });
 }
-
-
-
-

--- a/multigeiger/webconf.h
+++ b/multigeiger/webconf.h
@@ -19,23 +19,6 @@ extern char deveui[];
 extern char appkey[];
 #endif
 
-extern IotWebConfSeparator sep0;
-extern IotWebConfParameter startSoundParam;
-extern IotWebConfParameter speakerTickParam;
-extern IotWebConfParameter ledTickParam;
-extern IotWebConfParameter showDisplayParam;
-extern IotWebConfSeparator sep1;
-extern IotWebConfParameter sendToCommunityParam;
-extern IotWebConfParameter sendToMadaviParam;
-#if CPU==STICK
-extern IotWebConfSeparator sep3;
-extern IotWebConfParameter sendToLoraParam;
-extern IotWebConfParameter appeuiParam;
-extern IotWebConfParameter deveuiParam;
-extern IotWebConfParameter appkeyParam;
-#endif
-
-
 extern char ssid[];
 extern IotWebConf iotWebConf;
 

--- a/multigeiger/webconf.h
+++ b/multigeiger/webconf.h
@@ -24,6 +24,5 @@ extern char ssid[];
 extern IotWebConf iotWebConf;
 
 void setup_webconf(void);
-boolean parameterTrue(char *parameter);
 
 #endif // _WEBCONF_H_

--- a/multigeiger/webconf.h
+++ b/multigeiger/webconf.h
@@ -6,14 +6,15 @@
 
 #include "IotWebConf.h"
 
-extern char startSound[];
-extern char speakerTick[];
-extern char ledTick[];
-extern char showDisplay[];
-extern char sendToCommunity[];
-extern char sendToMadavi[];
+extern bool speakerTick;
+extern bool playSound;
+extern bool ledTick;
+extern bool showDisplay;
+extern bool sendToCommunity;
+extern bool sendToMadavi;
+extern bool sendToLora;
+
 #if CPU==STICK
-extern char sendToLora[];
 extern char appeui[];
 extern char deveui[];
 extern char appkey[];

--- a/multigeiger/webconf.h
+++ b/multigeiger/webconf.h
@@ -6,9 +6,40 @@
 
 #include "IotWebConf.h"
 
+extern char startSound[];
+extern char speakerTick[];
+extern char ledTick[];
+extern char showDisplay[];
+extern char sendToCommunity[];
+extern char sendToMadavi[];
+#if CPU==STICK
+extern char sendToLora[];
+extern char appeui[];
+extern char deveui[];
+extern char appkey[];
+#endif
+
+extern IotWebConfSeparator sep0;
+extern IotWebConfParameter startSoundParam;
+extern IotWebConfParameter speakerTickParam;
+extern IotWebConfParameter ledTickParam;
+extern IotWebConfParameter showDisplayParam;
+extern IotWebConfSeparator sep1;
+extern IotWebConfParameter sendToCommunityParam;
+extern IotWebConfParameter sendToMadaviParam;
+#if CPU==STICK
+extern IotWebConfSeparator sep3;
+extern IotWebConfParameter sendToLoraParam;
+extern IotWebConfParameter appeuiParam;
+extern IotWebConfParameter deveuiParam;
+extern IotWebConfParameter appkeyParam;
+#endif
+
+
 extern char ssid[];
 extern IotWebConf iotWebConf;
 
 void setup_webconf(void);
+boolean parameterTrue(char *parameter);
 
 #endif // _WEBCONF_H_


### PR DESCRIPTION
lorawan.cpp:
 - only compile, if CPU==STICK, i.e if we have LoRa Hardware
 - fetch LoRa credentials from config variables

multigeiger.ino:
 - use config variables instead of userdefines

transmission.cpp:
 - replace SEND2LORA by CPU==STICK
 - use config variables to decide where to send
 - send to LoRa only, if LoRa credentials are known

webconf.cpp
 - add all config variable to web page
 - do restart after saving config

userdefines-example.h
 - remove now unnecessary #defines