### PR TITLE
timer-driven adaptive recharging

### DIFF
--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -218,6 +218,7 @@ void tick_blink(unsigned long current_counts) {
 
 void loop() {
   static bool wifi_connected = false;
+  static bool hv_error = false;  // TODO: display this somewhere
 
   static bool have_thp = false;
   static float temperature = 0.0, humidity = 0.0, pressure = 0.0;
@@ -247,7 +248,7 @@ void loop() {
 
   read_THP(current_ms, &have_thp, &temperature, &humidity, &pressure);
 
-  hv_pulses += charge_hv(gm_counts, current_ms);
+  read_hv(&hv_error, &hv_pulses);
 
   display(current_ms, gm_counts, gm_count_timestamp, hv_pulses, wifi_connected);
 

--- a/multigeiger/timers.cpp
+++ b/multigeiger/timers.cpp
@@ -1,0 +1,12 @@
+#include <Arduino.h>
+
+#define RECHARGE_TIMER 0
+hw_timer_t *recharge_timer = NULL;
+
+void setup_recharge_timer(void (*isr_recharge)(), int period_us) {
+  recharge_timer = timerBegin(RECHARGE_TIMER, 80, true);  // prescaler: 80MHz / 80 == 1MHz
+  timerAttachInterrupt(recharge_timer, isr_recharge, true);  // set ISR
+  timerAlarmWrite(recharge_timer, period_us, true);  // set alarm after period, do repeat
+  timerWrite(recharge_timer, 0);
+  timerAlarmEnable(recharge_timer);
+}

--- a/multigeiger/timers.h
+++ b/multigeiger/timers.h
@@ -1,0 +1,2 @@
+void setup_recharge_timer(void (*isr_recharge)(), int period_us);
+

--- a/multigeiger/tube.cpp
+++ b/multigeiger/tube.cpp
@@ -5,6 +5,7 @@
 #include <Arduino.h>
 
 #include "log.h"
+#include "timers.h"
 #include "tube.h"
 
 // The test pin, if enabled, is high while isr_GMC_count is active.
@@ -35,20 +36,131 @@ TUBETYPE tubes[] = {
 
 volatile bool isr_GMC_cap_full;
 
+volatile unsigned long isr_hv_pulses;
+volatile bool isr_hv_charge_error;
+
 volatile unsigned int isr_GMC_counts;
 volatile unsigned long isr_count_timestamp;
 volatile unsigned long isr_count_time_between;
 
-static unsigned long hvpulse_timestamp;  // initialized via setup_tube -> gen_charge_pulses
-
 // MUX (mutexes used for mutual exclusive access to isr variables)
 portMUX_TYPE mux_cap_full = portMUX_INITIALIZER_UNLOCKED;
 portMUX_TYPE mux_GMC_count = portMUX_INITIALIZER_UNLOCKED;
+portMUX_TYPE mux_hv = portMUX_INITIALIZER_UNLOCKED;
+
+// Maximum amount of HV capacitor charge pulses to generate in one charge cycle.
+#define MAX_CHARGE_PULSES 3333
+
+// hw timer period and microseconds -> periods conversion
+#define PERIOD_DURATION_US 100
+#define PERIODS(us) ((us) / PERIOD_DURATION_US)
+
+void IRAM_ATTR isr_recharge() {
+  // this code is periodically called by a timer hw interrupt, always same period.
+  // we need to decide internally whether we actually want to do something.
+  //
+  // note: this is implemented like it is because dynamically reprogramming the hw timer
+  // to a different period would require us to call library functions like timerAlarmWrite
+  // which are **not** in IRAM (but in flash) and doing that can lead to spurious fatal
+  // exceptions like "Cache disabled but cached memory region accessed".
+  static unsigned int current = 0;  // current period counter
+  static unsigned int next_state = 0;  // periods to next state machine execution
+  static unsigned int next_charge = PERIODS(1000000);  // periods between recharges, initially 1s
+  if (current++ < next_state)
+    return;  // nothing to do yet
+
+  // we reached "next_state", so we execute the state machine:
+  current = 0;
+
+  enum State {init, pulse_h, pulse_l, check_full, is_full, charge_fail};
+  static State state = init;
+  static int charge_pulses;
+  if (state == init) {
+    charge_pulses = 0;
+    portENTER_CRITICAL_ISR(&mux_cap_full);
+    isr_GMC_cap_full = 0;
+    portEXIT_CRITICAL_ISR(&mux_cap_full);
+    state = pulse_h;
+    // fall through
+  }
+  while (state < is_full) {
+    if (state == pulse_h) {
+      digitalWrite(PIN_HV_FET_OUTPUT, HIGH);  // turn the HV FET on
+      state = pulse_l;
+      next_state = PERIODS(1500);  // 1500us (5000us gives 1.3 times more charge, 500us gives 1/20th of charge)
+      return;
+    }
+    if (state == pulse_l) {
+      digitalWrite(PIN_HV_FET_OUTPUT, LOW);   // turn the HV FET off
+      state = check_full;
+      next_state = PERIODS(1000);  // 1000us
+      return;
+    }
+    if (state == check_full) {
+      charge_pulses++;
+      if (isr_GMC_cap_full)
+        state = is_full;
+      else if (charge_pulses < MAX_CHARGE_PULSES)
+        state = pulse_h;
+      else
+        state = charge_fail;
+      // fall through
+    }
+  }
+  if (state == is_full) {
+    // capacitor full
+    portENTER_CRITICAL_ISR(&mux_hv);
+    isr_hv_charge_error = false;
+    isr_hv_pulses += charge_pulses;
+    portEXIT_CRITICAL_ISR(&mux_hv);
+    state = init;
+    // depending on a lot of circumstances (e.g. level of radiation, humidity,
+    // leak currents (diode leak current depends on temperature), tube type, ...),
+    // we might need to charge the HV capacitor more or less often.
+    // we target charging with 2 pulses here because if we only needed 1 charge
+    // pulse, this does not imply the HV capacitor actually needed charging. if
+    // we needed 2 pulses, we are sure the HV capacitor needed a little charge.
+    if (charge_pulses <= 1) {
+      // one charge pulse was enough, so maybe we charge too often
+      next_charge = next_charge * 5 / 4;
+    } else {
+      // 2 charge pulses: no change
+      // > 2: the more charge pulses we needed, the more frequently we want to recharge
+      next_charge = next_charge * 2 / charge_pulses;
+    }
+    // never go below 1ms or above 10s
+    if (next_charge < PERIODS(1000))
+      next_charge = PERIODS(1000);
+    else if (next_charge > PERIODS(10000000))
+      next_charge = PERIODS(10000000);
+    next_state = next_charge;
+    return;
+  }
+  if (state == charge_fail) {
+    // capacitor does not charge!
+    portENTER_CRITICAL_ISR(&mux_hv);
+    isr_hv_charge_error = true;
+    isr_hv_pulses += charge_pulses;
+    portEXIT_CRITICAL_ISR(&mux_hv);
+    // let's retry charging later
+    state = init;
+    next_charge = PERIODS(1000000);  // reset to default 1s charge interval
+    next_state = PERIODS(10 * 60 * 1000000);  // wait for 10 minutes before retrying
+    return;
+  }
+}
 
 void IRAM_ATTR isr_GMC_capacitor_full() {
   portENTER_CRITICAL_ISR(&mux_cap_full);
   isr_GMC_cap_full = 1;
   portEXIT_CRITICAL_ISR(&mux_cap_full);
+}
+
+void read_hv(bool *hv_error, unsigned long *pulses) {
+  portENTER_CRITICAL(&mux_hv);
+  *pulses = isr_hv_pulses;
+  *hv_error = isr_hv_charge_error;
+  portEXIT_CRITICAL(&mux_hv);
 }
 
 void IRAM_ATTR isr_GMC_count() {
@@ -83,50 +195,6 @@ void read_GMC(unsigned long *counts, unsigned long *timestamp, unsigned int *bet
   portEXIT_CRITICAL(&mux_GMC_count);
 }
 
-// How many HV capacitor charge pulses to generate before giving up.
-// (MAX_CHARGE_PULSES * pulse_duration) should be less than the interval in
-// the main loop (currently 1000ms) where it unconditionally recharges.
-#define MAX_CHARGE_PULSES 333
-
-// How many HV capacitor charge pulses to generate for first charge,
-// for the call in setup(). Not timing critical and capacitor is empty.
-#define MAX_CHARGE_PULSES_INITIAL 3333
-
-// Interval for unconditional HV charge pulse generation. [msec]
-#define HVPULSE_MS 1000
-
-// After this many GM counts, we want to recharge the HV capacitor, too.
-#define HVPULSE_COUNTS 100
-
-int charge_hv(unsigned long current_counts, unsigned long current_ms) {
-  // Charge the HV capacitor every HVPULSE_COUNTS or HVPULSE_MS.
-  static unsigned long last_counts = 0;
-  int HV_pulse_count = 0;
-  if (((current_counts - last_counts) >= HVPULSE_COUNTS) || ((current_ms - hvpulse_timestamp) >= HVPULSE_MS)) {
-    HV_pulse_count = gen_charge_pulses(false);
-    last_counts = current_counts;
-  }
-  return HV_pulse_count;
-}
-
-int gen_charge_pulses(bool setup) {
-  // charge HV capacitor
-  int max_charge_pulses = setup ? MAX_CHARGE_PULSES_INITIAL : MAX_CHARGE_PULSES;
-  int charge_pulses = 0;
-  isr_GMC_cap_full = 0;
-  do {
-    digitalWrite(PIN_HV_FET_OUTPUT, HIGH);              // turn the HV FET on
-    delayMicroseconds(1500);                            // 5000 usec gives 1,3 times more charge, 500 usec gives 1/20 th of charge
-    digitalWrite(PIN_HV_FET_OUTPUT, LOW);               // turn the HV FET off
-    delayMicroseconds(1000);
-    charge_pulses++;
-  } while ((charge_pulses < max_charge_pulses) && !isr_GMC_cap_full); // either a timeout or a capacitor full interrupt stops this loop
-  hvpulse_timestamp = millis();
-  if ((charge_pulses == max_charge_pulses) && !isr_GMC_cap_full)
-    log(CRITICAL, "HV charging failed!");               // pulsed a lot, but still the capacitor is not at desired voltage
-  return charge_pulses;
-}
-
 void setup_tube(void) {
   pinMode(PIN_TEST_OUTPUT, OUTPUT);
   pinMode(PIN_HV_FET_OUTPUT, OUTPUT);
@@ -144,9 +212,11 @@ void setup_tube(void) {
   isr_count_time_between = now_us;
   isr_GMC_cap_full = 0;
   isr_GMC_counts = 0;
+  isr_hv_pulses = 0;
+  isr_hv_charge_error = false;
 
   attachInterrupt(digitalPinToInterrupt(PIN_HV_CAP_FULL_INPUT), isr_GMC_capacitor_full, RISING);  // capacitor full
   attachInterrupt(digitalPinToInterrupt(PIN_GMC_COUNT_INPUT), isr_GMC_count, FALLING);            // GMC pulse detected
 
-  gen_charge_pulses(true);
+  setup_recharge_timer(isr_recharge, PERIOD_DURATION_US);
 }

--- a/multigeiger/tube.h
+++ b/multigeiger/tube.h
@@ -11,9 +11,8 @@ typedef struct {
 
 extern TUBETYPE tubes[];
 
-int charge_hv(unsigned long current_counts, unsigned long current_ms);
-int gen_charge_pulses(bool setup);
 void setup_tube(void);
 void read_GMC(unsigned long *counts, unsigned long *timestamp, unsigned int *between);
+void read_hv(bool *hv_error, unsigned long *pulses);
 
 #endif // _TUBE_H_


### PR DESCRIPTION
This does all HV charging via a timer driven ISR.

This fixes #192, but in an improved way:

Just doing a HV charge pulse "every second" is not good enough:
- if radiation-caused discharging and discharging caused by other leaks are low, a pulse every second is more than needed. No big problem, just drawing more power than needed.
- if radiation or leaks are high, doing only 1 pulse per second is not enough, so we need to adapt to not let the HV voltage break down.

The code adapts to this by targeting a 2-pulse recharge.

Due to the way we charge, we always will have 1 charge pulse - no matter whether we actually needed to charge or not. But 2 pulses are only needed if we really needed to charge. Thus the code targets doing 2 pulses.

If less than 2 pulses are needed, we are maybe charging too often - the code will then slightly increase the time between charge cycles.

If 2 pulses are needed, do not change the timer interval.

If more than 2 pulses are needed, we are charging too infrequently, decrease the time between charge cycles. This is done proportional to `1 / charge_pulses_needed`. So, if we encounter high radiation, have a high discharge and need many recharge pulses, we will quickly adapt to recharging way more frequently.

If HV charging fails, the code sets a `hv_error` variable in main loop now, but it is not used there yet.