### PR TITLE
fix/refactor clearDisplayLine

### DIFF
--- a/multigeiger/display.cpp
+++ b/multigeiger/display.cpp
@@ -65,11 +65,9 @@ void setup_display(bool loraHardware) {
 }
 
 void clearDisplayLine(int line) {
-  char blank[17] = "                ";
-  if (isLoraBoard) {
-    blank[9] = '\0';
-  }
-  pu8x8->drawString(0, line, blank);
+  const char *blanks;
+  blanks = isLoraBoard ? "        " : "                "; // 8 / 16
+  pu8x8->drawString(0, line, blanks);
 }
 
 void displayStatusLine(String txt) {


### PR DESCRIPTION
the old code put the terminating \0 at the wrong place,
so the result was 9 chars wide instead of the desired 8.

the new code avoids this issue and is also simpler.