### PR TITLE
add bme680 library for basic THP readout of BME680

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,19 @@ Diverse Software-Einstellungen kann man über folgende Dateien machen (siehe Kom
  * **./multigeiger/userdefines.h** (immer notwendig, ein Beispiel hierzu wird in userdefines-example.h mitgeliefert)
  * **./platformio.ini** (nur bei platformio, ein Beispiel hierzu wird in platformio-example.ini mitgeliefert)
 
-Als externe Libraries werden benötigt:
-
- * U8g2 von Oliver, Version >=2.26.14
- * Adafruit BME280 Library, Version >=2.0.0
- * Adafruit Unified Sensor, Version >=1.0.3
- * IotWebConf, Version >=2.3.0
- * MCCI LoRaWAN LMIC library, Version >= 2.3.2\
- **Achtung:** Wenn die Arduino-IDE verwendet wird, dann bitte prüfen, dass in der Datei project_config/lmic_project_config.h (in der obersten Ebene in dieser Library) unbedingt
-die richtigen Configs eingestellt sind. Die Datei muss folgendermassen aussehen:
+Es werden alle externen Libraries benötigt, die in der Datei 
 ```
+platformio-example.ini
+```
+unter dem Abschnitt 
+```
+lib-deps =
+```
+aufgelistet sind. Bitte jeweils die aktuellste Version über platform.io / Libraries installieren.
+
+ **Achtung:** Wenn die Arduino-IDE verwendet wird, dann bitte prüfen, dass in der Datei project_config/lmic_project_config.h (in der obersten Ebene in dieser Library) unbedingt
+```
+die richtigen Configs eingestellt sind. Die Datei muss folgendermassen aussehen:
 // project-specific definitions
 #define CFG_eu868 1
 //#define CFG_us915 1

--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -190,7 +190,7 @@ void read_THP(unsigned long current_ms,
     last_timestamp = current_ms;
     *have_thp = read_thp_sensor(temperature, humidity, pressure);
     if (*have_thp)
-      log(DEBUG, "Measured THP: T=%.2f H=%.f P=%.f", *temperature, *humidity, *pressure);
+      log(INFO, "Measured THP: T=%.2f H=%.f P=%.f", *temperature, *humidity, *pressure);
   }
 }
 

--- a/multigeiger/thp_sensor.cpp
+++ b/multigeiger/thp_sensor.cpp
@@ -4,29 +4,69 @@
 
 #include <Adafruit_Sensor.h>
 #include <Adafruit_BME280.h>
+#include <Adafruit_BME680.h>
 
 #include "log.h"
 #include "thp_sensor.h"
 
-static bool have_thp = false;
+static int type_thp = 0;
 
-Adafruit_BME280 bme;
+Adafruit_BME280 bme280;
+Adafruit_BME680 bme680;
 
 bool setup_thp_sensor(void) {
-  have_thp = (bool) bme.begin(BME280_ADDRESS);
-  if (!have_thp)
-    have_thp = (bool) bme.begin(BME280_ADDRESS_ALTERNATE);
-  if (have_thp)
-    log(INFO, "BME_Status: %d  ID:%0X", (int) have_thp, bme.sensorID());
-  else
-    log(INFO, "BME_Status: %d  ID:None", (int) have_thp);
-  return have_thp;
+  // BME280
+  if (bme280.begin(BME280_ADDRESS))
+    type_thp = 280;
+  else if (bme280.begin(BME280_ADDRESS_ALTERNATE))
+    type_thp = 280;
+
+  // BME680
+  if (type_thp == 0) {
+    if (bme680.begin(BME680_I2C_ADDR_PRIMARY))
+      type_thp = 680;
+    else if (bme680.begin(BME680_I2C_ADDR_SECONDARY))
+      type_thp = 680;
+  }
+
+  switch (type_thp) {
+  case 680:
+    // Set up oversampling and filter initialization
+    bme680.setTemperatureOversampling(BME680_OS_8X);
+    bme680.setHumidityOversampling(BME680_OS_2X);
+    bme680.setPressureOversampling(BME680_OS_4X);
+    bme680.setIIRFilterSize(BME680_FILTER_SIZE_3);
+    bme680.setGasHeater(300, 150); // 300*C for 150 ms
+    log(INFO, "BME_Status: ok,  ID: BME680");
+    break;
+  case 280:
+    log(INFO, "BME_Status: ok,  ID: BME280");
+    break;
+  default:
+    log(INFO, "BME_Status: not found");
+    break;
+  }
+  return (type_thp > 0);
 }
 
 bool read_thp_sensor(float *temperature, float *humidity, float *pressure) {
-  *temperature = have_thp ? bme.readTemperature() : 0.0;
-  *humidity = have_thp ? bme.readHumidity() : 0.0;
-  *pressure = have_thp ? bme.readPressure() : 0.0;
-  return have_thp;
+  if (type_thp == 280) {
+    *temperature = bme280.readTemperature();
+    *humidity = bme280.readHumidity();
+    *pressure = bme280.readPressure();
+  } else if (type_thp == 680) {
+    if (!bme680.performReading()) {
+      log(INFO, "BME680: Failed to perform reading");
+      return false;
+    }
+    *temperature = bme680.temperature;
+    *humidity = bme680.humidity;
+    *pressure = bme680.pressure;
+  } else {
+    *temperature = 0.0;
+    *humidity = 0.0;
+    *pressure = 0.0;
+  }
+  return (type_thp > 0);
 }
 

--- a/platformio-example.ini
+++ b/platformio-example.ini
@@ -25,6 +25,7 @@ framework = arduino
 monitor_speed=115200
 lib_deps=
   U8g2
+  Adafruit BME680 Library
   Adafruit BME280 Library
   Adafruit Unified Sensor
   IotWebConf


### PR DESCRIPTION
After wondering some time why my THP stopped working after the FW update, I noticed it's an BME680 board. This PR adds BME680 lib to allow transparent readout of THP only from BME680 as well as from BME280.
Future option to read and log gas resistance value for air quality changes not considered here.