### PR TITLE
status display: keep showing transmission errors

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -42,21 +42,21 @@ Positions:
 - 1: sensors.community transmission
 
   - ``.``: off (not configured / enabled)
-  - ``s``: idle
   - ``S``: sending
-  - ``1``: transmission failed
+  - ``s``: idle (shown after successful sending)
+  - ``1``: sending failed (shown after trying to send)
 - 2: madavi transmission
 
   - ``.``: off (not configured / enabled)
-  - ``m``: idle
   - ``M``: sending
-  - ``2``: transmission failed
+  - ``m``: idle (shown after successful sending)
+  - ``2``: sending failed (shown after trying to send)
 - 3: TTN ("The Things Network")
 
-  - ``.``: off (no LoRa hardware, not configured, not enabled)
-  - ``t``: idle
+  - ``.``: off (not configured, not enabled, no LoRa hardware)
   - ``T``: sending
-  - ``3``: some error happened
+  - ``t``: idle (shown after successful sending)
+  - ``3``: sending failed (shown after trying to send)
 - 4: reserved for BT
 - 5: unused
 - 6: unused

--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -252,6 +252,9 @@ void loop() {
   read_THP(current_ms, &have_thp, &temperature, &humidity, &pressure);
 
   read_hv(&hv_error, &hv_pulses);
+  set_status(STATUS_HV, hv_error ? ST_HV_ERROR : ST_HV_OK);
+
+  int wifi_status = update_wifi_status();
 
   display(current_ms, gm_counts, gm_count_timestamp, hv_pulses);
 
@@ -266,15 +269,4 @@ void loop() {
   long loop_duration;
   loop_duration = millis() - current_ms;
   iotWebConf.delay((loop_duration < LOOP_DURATION) ? (LOOP_DURATION - loop_duration) : 0);
-
-  int wifi_status = update_wifi_status();
-
-  set_status(STATUS_SCOMM, ((wifi_status == ST_WIFI_CONNECTED) && sendToCommunity) ? ST_SCOMM_IDLE : ST_SCOMM_OFF);
-  set_status(STATUS_MADAVI, ((wifi_status == ST_WIFI_CONNECTED) && sendToMadavi) ? ST_MADAVI_IDLE : ST_MADAVI_OFF);
-
-  set_status(STATUS_TTN, sendToLora ? ST_TTN_IDLE : ST_TTN_OFF);
-
-  set_status(STATUS_BT, ST_NODISPLAY);  // TODO
-
-  set_status(STATUS_HV, hv_error ? ST_HV_ERROR : ST_HV_OK);
 }


### PR DESCRIPTION
in case of some unsuccessful transmission attempt, the error code was
only shown for a short time and then replaced by idle status again.

fixed, now the error code is shown until the transmission is retried.

also removed some unneeded status display related code for BT and LoRa,
the initial state is "NODISPLAY" anyway.