### PR TITLE
Fix #373: Improve LoRaWAN stability

### DIFF
--- a/multigeiger/loraWan.cpp
+++ b/multigeiger/loraWan.cpp
@@ -218,6 +218,10 @@ void setup_lorawan() {
   LMIC_setDrTxpow(DR_SF7, 14);
 }
 
+void poll_lorawan() {
+  os_runloop_once();
+}
+
 // Send LoRaWan frame with ack or not
 // - txPort : port to transmit
 // - txBuffer : message to transmit

--- a/multigeiger/loraWan.cpp
+++ b/multigeiger/loraWan.cpp
@@ -233,8 +233,8 @@ void poll_lorawan() {
 // - rxSz : size of received data
 transmissionStatus_t lorawan_send(uint8_t txPort, uint8_t *txBuffer, uint8_t txSz, bool ack, uint8_t *rxPort, uint8_t *rxBuffer, uint8_t *rxSz) {
   // Check if there is not a current TX/RX job running
-  if (LMIC.opmode & OP_TXRXPEND) {
-    log(DEBUG, "OP_TXRXPEND, not sending");
+  if (LMIC.opmode & (OP_POLL | OP_TXDATA | OP_TXRXPEND)) {
+    log(DEBUG, "OP_POLL | OP_TXDATA | OP_TXRXPEND, not sending");
     return TX_STATUS_ENDING_ERROR;
   } else {
     txStatus = TX_STATUS_UNKNOWN;

--- a/multigeiger/loraWan.h
+++ b/multigeiger/loraWan.h
@@ -16,6 +16,9 @@ typedef enum {
 #define LORA_TIMEOUT_MS 30000L
 
 void setup_lorawan();
+
+// call os_runloop_once(); a separate function to keep the LMIC header files mostly hidden.
+void poll_lorawan();
 transmissionStatus_t lorawan_send(uint8_t txPort, uint8_t *txBuffer, uint8_t txSz, bool ack, uint8_t *rxPort, uint8_t *rxBuffer, uint8_t *rxSz);
 
 #endif // _LORAWAN_H_

--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -268,6 +268,9 @@ void loop() {
 
   update_ble_status();
 
+  // do any other periodic updates for uplinks
+  poll_transmission();
+
   publish(current_ms, gm_counts, gm_count_timestamp, hv_pulses);
 
   if (Serial_Print_Mode == Serial_One_Minute_Log)

--- a/multigeiger/transmission.cpp
+++ b/multigeiger/transmission.cpp
@@ -74,6 +74,16 @@ void setup_transmission(const char *version, char *ssid, bool loraHardware) {
   set_status(STATUS_TTN, sendToLora ? ST_TTN_INIT : ST_TTN_OFF);
 }
 
+void poll_transmission() {
+  if (isLoraBoard) {
+    // The LMIC needs to be polled a lot; and this is very low cost if the LMIC isn't
+    // active. So we just act as a bridge. We need this routine so we can see
+    // `isLoraBoard`. Most C compilers will notice the tail call and optimize this
+    // to a jump.
+    poll_lorawan();
+  }
+}
+
 void prepare_http(HttpsClient *client, const char *host) {
   if (host[4] == 's')  // https
     client->hc->begin(*client->wc, host);

--- a/multigeiger/transmission.h
+++ b/multigeiger/transmission.h
@@ -18,4 +18,7 @@ void setup_transmission(const char *version, char *ssid, bool lora);
 void transmit_data(String tube_type, int tube_nbr, unsigned int dt, unsigned int hv_pulses, unsigned int gm_counts, unsigned int cpm,
                    int have_thp, float temperature, float humidity, float pressure, int wifi_status);
 
+// The Arduino LMIC wants to be polled from loop(). This takes care of that on LoRa boards.
+void poll_transmission(void);
+
 #endif // _TRANSMISSION_H_


### PR DESCRIPTION
This PR has two distinct changesets.

- Add LMIC polling from loop (https://github.com/ecocurious2/MultiGeiger/commit/134159f33534ce9a21f904499fc5aed76661cca7). The LMIC requires continous polling while it's active; "activity" can go on a long time, because it's based on network activity and internal state. Polling the LMIC takes essentially no time if there's nothing in the queue, so this will not disturb things in the rest of the app.

- Work around LMIC bug 677 (https://github.com/ecocurious2/MultiGeiger/commit/b8d13b5072a59881cd0569418420debd454abc99). The lack of polling uncovered another problem, which is that the LMIC was not checking all the important flags to prevent transmitting while the LMIC is busy. The correction prevent that. The change will be redundant once the LMIC incorporates the fix, but not harmful.

I also have a similar patch for V1.14.0; if you like I will push it (otherwise it can be found in the fork, released as https://github.com/terrillmoore/MultiGeiger/releases/tag/V1.14.1-beta2).

I do not have a multigeiger, so testing was done by @perpaul, and he reports that this corrected his stability problems.

I think this addresses your issue #373.