### PR TITLE
Fix Adafruit BME680 lib V2.0 #macro name change

### DIFF
--- a/multigeiger/thp_sensor.cpp
+++ b/multigeiger/thp_sensor.cpp
@@ -23,9 +23,9 @@ bool setup_thp_sensor(void) {
 
   // BME680
   if (type_thp == 0) {
-    if (bme680.begin(BME680_I2C_ADDR_PRIMARY))
+    if (bme680.begin(BME68X_I2C_ADDR_LOW))
       type_thp = 680;
-    else if (bme680.begin(BME680_I2C_ADDR_SECONDARY))
+    else if (bme680.begin(BME68X_I2C_ADDR_HIGH))
       type_thp = 680;
   }
 

--- a/platformio-example.ini
+++ b/platformio-example.ini
@@ -25,7 +25,7 @@ framework = arduino
 monitor_speed=115200
 lib_deps=
   U8g2
-  Adafruit BME680 Library
+  Adafruit BME680 Library@^2.0.0
   Adafruit BME280 Library
   Adafruit Unified Sensor
   IotWebConf@<3.0.0


### PR DESCRIPTION
BME680 I2C address defines were changed in 'bme68x_defs.h' from Adafruit BME680 lib V2.0.0 to:
BME68X_I2C_ADDR_LOW / _HIGH
instead of _PRIMARY / _SECONDARY

Fixed here.