### PR TITLE
BLE via NimBLE-Arduino lib

### DIFF
--- a/multigeiger/ble.cpp
+++ b/multigeiger/ble.cpp
@@ -14,23 +14,15 @@
 #include "ble.h"
 #include "display.h"
 
-#include <BLEDevice.h>
-#include <BLEServer.h>
-#include <BLEUtils.h>
-#include <BLE2902.h>
+#include <NimBLEDevice.h>
+
+static NimBLEServer *bleServer;
 
 #define BLE_SERVICE_HEART_RATE    BLEUUID((uint16_t)0x180D)  // 16 bit UUID of Heart Rate Service
 #define BLE_CHAR_HR_MEASUREMENT   BLEUUID((uint16_t)0x2A37)  // 16 bit UUID of Heart Rate Measurement Characteristic
 #define BLE_CHAR_HR_POSITION      BLEUUID((uint16_t)0x2A38)  // 16 bit UUID of Heart Rate Sensor Position Characteristic
 #define BLE_CHAR_HR_CONTROLPOINT  BLEUUID((uint16_t)0x2A39)  // 16 bit UUID of Heart Rate Control Point Characteristic
 #define BLE_DESCR_UUID            BLEUUID((uint16_t)0x2901)  // 16 bit UUID of BLE Descriptor
-
-BLECharacteristic bleCharHRM(BLE_CHAR_HR_MEASUREMENT, BLECharacteristic::PROPERTY_NOTIFY);
-BLEDescriptor bleDescriptorHRM(BLE_DESCR_UUID);
-BLECharacteristic bleCharHRCP(BLE_CHAR_HR_CONTROLPOINT, BLECharacteristic::PROPERTY_WRITE);
-BLEDescriptor bleDescriptorHRCP(BLE_DESCR_UUID);
-BLECharacteristic bleCharHRPOS(BLE_CHAR_HR_POSITION, BLECharacteristic::PROPERTY_READ);
-BLEDescriptor bleDescriptorHRPOS(BLE_DESCR_UUID);
 
 static bool ble_enabled = false;
 static bool device_connected = false;
@@ -45,32 +37,21 @@ bool is_ble_connected(void) {
   return ble_enabled && device_connected;
 }
 
-class MyServerCallbacks: public BLEServerCallbacks {
-  void onConnect(BLEServer *pServer, esp_ble_gatts_cb_param_t *param) {
-    char remoteAddress[18];
-    sprintf(
-      remoteAddress,
-      "%02X:%02X:%02X:%02X:%02X:%02X",
-      param->connect.remote_bda[0],
-      param->connect.remote_bda[1],
-      param->connect.remote_bda[2],
-      param->connect.remote_bda[3],
-      param->connect.remote_bda[4],
-      param->connect.remote_bda[5]
-    );
-    log(INFO, "BLE device connected, remote MAC: %s", remoteAddress);
+class MyServerCallbacks: public NimBLEServerCallbacks {
+  void onConnect(NimBLEServer *pServer, ble_gap_conn_desc *desc) {
+    log(INFO, "BLE device connected, remote MAC: %s", NimBLEAddress(desc->peer_ota_addr).toString().c_str());
     device_connected = true;
   };
 
-  void onDisconnect(BLEServer *pServer) {
+  void onDisconnect(NimBLEServer *pServer) {
     device_connected = false;
     log(INFO, "BLE device disconnected");
   }
 };
 
 // Callback allowing for Control Point Characteristic to reset "energy expenditure" (packet counter)
-class MyCharacteristicCallbacks: public BLECharacteristicCallbacks {
-  void onWrite(BLECharacteristic *pCharacteristic) {
+class MyCharacteristicCallbacks: public NimBLECharacteristicCallbacks {
+  void onWrite(NimBLECharacteristic *pCharacteristic) {
     String rxValue = pCharacteristic->getValue().c_str();
     status_HRCP = (rxValue.length() > 0) ? (unsigned int)rxValue[0] : 0;
   }
@@ -91,8 +72,16 @@ void update_bledata(unsigned int cpm) {
   txBuffer_HRM[2] = (cpm >> 8) & 0xFF;
   txBuffer_HRM[3] = cpm_update_counter & 0xFF;
   txBuffer_HRM[4] = (cpm_update_counter >> 8) & 0xFF;
-  bleCharHRM.setValue(txBuffer_HRM, 5);
-  bleCharHRM.notify();
+  if (bleServer->getConnectedCount()) {
+    NimBLEService *bleSvc = bleServer->getServiceByUUID(BLE_SERVICE_HEART_RATE);
+    if (bleSvc) {
+      NimBLECharacteristic *bleChr = bleSvc->getCharacteristic(BLE_CHAR_HR_MEASUREMENT);
+      if (bleChr) {
+        bleChr->setValue(txBuffer_HRM, 5);
+        bleChr->notify();
+      }
+    }
+  }
 }
 
 void setup_ble(char *device_name, bool ble_on) {
@@ -104,29 +93,35 @@ void setup_ble(char *device_name, bool ble_on) {
   ble_enabled = true;
 
   set_status(STATUS_BLE, ST_BLE_INIT);
-  BLEDevice::init(device_name);
+  NimBLEDevice::init(device_name);
 
-  BLEServer *bleServer = BLEDevice::createServer();
+  bleServer = NimBLEDevice::createServer();
   bleServer->setCallbacks(new MyServerCallbacks());
 
-  BLEService *bleService = bleServer->createService(BLE_SERVICE_HEART_RATE);
+  NimBLEService *bleService = bleServer->createService(BLE_SERVICE_HEART_RATE);
 
-  bleService->addCharacteristic(&bleCharHRM);
-  bleDescriptorHRM.setValue("Radiation rate CPM");
-  bleCharHRM.addDescriptor(&bleDescriptorHRM);
-  bleCharHRM.addDescriptor(new BLE2902());  // required for notification management of the service
+// NimBLECharacteristic bleCharHRM(BLE_CHAR_HR_MEASUREMENT, NIMBLE_PROPERTY::NOTIFY);
+  NimBLECharacteristic *bleCharHRM = bleService->createCharacteristic(BLE_CHAR_HR_MEASUREMENT, NIMBLE_PROPERTY::NOTIFY);
+// NimBLEDescriptor bleDescriptorHRM(BLE_DESCR_UUID);
+  NimBLEDescriptor *bleDescriptorHRM = bleCharHRM->createDescriptor("Radiation rate CPM", NIMBLE_PROPERTY::READ);
+//  bleCharHRM.addDescriptor(new BLE2902());  // required for notification management of the service
 
-  bleService->addCharacteristic(&bleCharHRCP);
-  bleDescriptorHRCP.setValue("0x01 for Energy Exp. (packet counter) reset");
-  bleCharHRCP.addDescriptor(&bleDescriptorHRCP);
-  bleCharHRCP.setCallbacks(new MyCharacteristicCallbacks());
+// NimBLECharacteristic bleCharHRCP(BLE_CHAR_HR_CONTROLPOINT, NIMBLE_PROPERTY::WRITE);
+  NimBLECharacteristic *bleCharHRCP = bleService->createCharacteristic(BLE_CHAR_HR_CONTROLPOINT, NIMBLE_PROPERTY::WRITE);
+// NimBLEDescriptor bleDescriptorHRCP(BLE_DESCR_UUID);
+  NimBLEDescriptor *bleDescriptorHRCP = bleCharHRM->createDescriptor("0x01 for Energy Exp. (packet counter) reset", NIMBLE_PROPERTY::READ);
+// NimBLECharacteristic bleCharHRPOS(BLE_CHAR_HR_POSITION, NIMBLE_PROPERTY::READ);
+  NimBLECharacteristic *bleCharHRPOS = bleService->createCharacteristic(BLE_CHAR_HR_POSITION, NIMBLE_PROPERTY::READ);
+// NimBLEDescriptor bleDescriptorHRPOS(BLE_DESCR_UUID);
+  NimBLEDescriptor *bleDescriptorHRPOS = bleCharHRM->createDescriptor("Geiger Mueller Tube Type", NIMBLE_PROPERTY::READ);
+  bleCharHRCP->setCallbacks(new MyCharacteristicCallbacks());
 
-  bleService->addCharacteristic(&bleCharHRPOS);
-  bleDescriptorHRPOS.setValue("Geiger Mueller Tube Type");
-  bleCharHRPOS.addDescriptor(&bleDescriptorHRPOS);
-  bleCharHRPOS.setValue(txBuffer_HRPOS, 1);
+  bleCharHRPOS->setValue(txBuffer_HRPOS, 1);
 
   bleServer->getAdvertising()->addServiceUUID(BLE_SERVICE_HEART_RATE);
+  bleServer->getAdvertising()->setScanResponse(true);
+  bleServer->getAdvertising()->setMinPreferred(0x06);
+  bleServer->getAdvertising()->setMinPreferred(0x12);
 
   bleService->start();
   bleServer->getAdvertising()->start();

--- a/platformio-example.ini
+++ b/platformio-example.ini
@@ -30,3 +30,4 @@ lib_deps=
   Adafruit Unified Sensor
   IotWebConf@<3.0.0
   MCCI LoRaWAN LMIC library
+  h2zero/NimBLE-Arduino


### PR DESCRIPTION
Swapped BLE management from Arduino to [NimBLE](https://github.com/h2zero/NimBLE-Arduino) to save RAM and flash.
Changes running locally for a while already under 1.15-dev. Now ported to 1.16-dev.
Includes changes required for Adafruit BME680 V2.0.0.

Before:
RAM:   [==        ]  20.4% (used 66744 bytes from 327680 bytes) 
Flash: [=====     ]  52.4% (used 1752965 bytes from 3342336 bytes)

After:
RAM:   [==        ]  18.9% (used 62032 bytes from 327680 bytes) 
Flash: [====      ]  40.1% (used 1340817 bytes from 3342336 bytes)