### PR TITLE
Fix sensor.community domain

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -71,7 +71,7 @@ New features:
   - use persistent per-server HTTPClient instances
   - use connection: keep-alive for web requests
   - add https capability (can be used for sending data)
-  - note: transmission to sensors.community and madavi is still using http!
+  - note: transmission to sensor.community and madavi is still using http!
 
 Fixes:
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -39,7 +39,7 @@ Positions:
   - ``w``: WiFi client trying to connect
   - ``W``: WiFi client connected
   - ``0``: some error happened
-- 1: sensors.community transmission
+- 1: sensor.community transmission
 
   - ``.``: off (not configured, not enabled)
   - ``?``: init (enabled, before 1st transmission)

--- a/locales/de/LC_MESSAGES/changes.po
+++ b/locales/de/LC_MESSAGES/changes.po
@@ -171,7 +171,7 @@ msgstr ""
 
 #: ../../source/changes.rst:56 dcf82fad98b24c8fa41cad0e23146d0a
 msgid ""
-"note: transmission to sensors.community and madavi is still using http!"
+"note: transmission to sensor.community and madavi is still using http!"
 msgstr ""
 
 #: ../../source/changes.rst:60 93d035320ce24113bbb79aa68dee4a52

--- a/locales/de/LC_MESSAGES/usage.po
+++ b/locales/de/LC_MESSAGES/usage.po
@@ -100,8 +100,8 @@ msgid "``0``: some error happened"
 msgstr "``0``: ein Fehler ist aufgetreten"
 
 #: ../../source/usage.rst:42 c1d7bb7d22f54bbb82bd0fff3198d98b
-msgid "1: sensors.community transmission"
-msgstr "1: sensors.community-Übertragung"
+msgid "1: sensor.community transmission"
+msgstr "1: sensor.community-Übertragung"
 
 #: ../../source/usage.rst:44 ../../source/usage.rst:51
 #: b703c1376a7d4265a0227bd86a66da07 b703c1376a7d4265a0227bd86a66da07

--- a/multigeiger/webconf.cpp
+++ b/multigeiger/webconf.cpp
@@ -40,7 +40,7 @@ IotWebConfParameter ledTickParam = BOOL_PARAM("LED tick", "ledTick", ledTick_c);
 IotWebConfParameter showDisplayParam = BOOL_PARAM("Show display", "showDisplay", showDisplay_c);
 
 IotWebConfSeparator sep1 = IotWebConfSeparator("Transmission settings");
-IotWebConfParameter sendToCommunityParam = BOOL_PARAM("Send to sensors.community", "send2Community", sendToCommunity_c);
+IotWebConfParameter sendToCommunityParam = BOOL_PARAM("Send to sensor.community", "send2Community", sendToCommunity_c);
 IotWebConfParameter sendToMadaviParam = BOOL_PARAM("Send to madavi.de", "send2Madavi", sendToMadavi_c);
 IotWebConfParameter sendToBleParam = BOOL_PARAM("Send to BLE (Reboot required!)", "send2ble", sendToBle_c);
 


### PR DESCRIPTION
The config page and the docs referred to `sensors.community`, which is a different service.