### PR TITLE
Iot 3.1

### DIFF
--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -79,13 +79,13 @@ void setup_ntp(int wifi_status) {
 int update_wifi_status(void) {
   int st;
   switch (iotWebConf.getState()) {
-  case IOTWEBCONF_STATE_CONNECTING:
+  case iotwebconf::Connecting:
     st = ST_WIFI_CONNECTING;
     break;
-  case IOTWEBCONF_STATE_ONLINE:
+  case iotwebconf::OnLine:
     st = ST_WIFI_CONNECTED;
     break;
-  case IOTWEBCONF_STATE_AP_MODE:
+  case iotwebconf::ApMode:
     st = ST_WIFI_AP;
     break;
   default:

--- a/platformio-example.ini
+++ b/platformio-example.ini
@@ -28,6 +28,6 @@ lib_deps=
   Adafruit BME680 Library@^2.0.0
   Adafruit BME280 Library
   Adafruit Unified Sensor
-  IotWebConf
+  IotWebConf@^3.1.0
   MCCI LoRaWAN LMIC library
   h2zero/NimBLE-Arduino


### PR DESCRIPTION
Only three very small changes were necessary. Now it compiles with iotwebconf 3.1.0 (but no longer with elder versions).
OTA tested, works.