### PR TITLE
fix uptime display - casting brackets

### DIFF
--- a/multigeiger/display.cpp
+++ b/multigeiger/display.cpp
@@ -131,8 +131,8 @@ void display_status(void) {
 
 char *format_time(unsigned int secs) {
   static char result[4];
-  int mins = secs / 60;
-  int hours = secs / (60 * 60);
+  unsigned int mins = secs / 60;
+  unsigned int hours = secs / (60 * 60);
   unsigned int days = secs / (24 * 60 * 60);
   if (secs < 60) {
     snprintf(result, 4, "%2ds", secs);

--- a/multigeiger/display.cpp
+++ b/multigeiger/display.cpp
@@ -129,11 +129,11 @@ void display_status(void) {
   display_statusline(output);
 }
 
-char *format_time(int secs) {
+char *format_time(unsigned int secs) {
   static char result[4];
   int mins = secs / 60;
   int hours = secs / (60 * 60);
-  int days = secs / (24 * 60 * 60);
+  unsigned int days = secs / (24 * 60 * 60);
   if (secs < 60) {
     snprintf(result, 4, "%2ds", secs);
   } else if (mins < 60) {
@@ -147,7 +147,7 @@ char *format_time(int secs) {
   return result;
 }
 
-void display_GMC(int TimeSec, int RadNSvph, int CPM, bool use_display) {
+void display_GMC(unsigned int TimeSec, int RadNSvph, int CPM, bool use_display) {
   if (!use_display) {
     if (!displayIsClear) {
       pu8x8->clear();

--- a/multigeiger/display.h
+++ b/multigeiger/display.h
@@ -4,7 +4,7 @@
 #define _DISPLAY_H_
 
 void setup_display(bool loraHardware);
-void display_GMC(int TimeSec, int RadNSvph, int CPM, bool use_display);
+void display_GMC(unsigned int TimeSec, int RadNSvph, int CPM, bool use_display);
 void clear_displayline(int line);
 void display_statusline(String txt);
 

--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -145,7 +145,7 @@ void publish(unsigned long current_ms, unsigned long current_counts, unsigned lo
 
     // ... and update the data on display, notify via BLE
     update_bledata((unsigned int)(Count_Rate * 60));
-    display_GMC(((int)accumulated_time / 1000), (int)(accumulated_Dose_Rate * 1000), (int)(Count_Rate * 60),
+    display_GMC((unsigned int)(accumulated_time / 1000), (int)(accumulated_Dose_Rate * 1000), (int)(Count_Rate * 60),
                 (showDisplay && switches.display_on));
 
     // Sound local alarm?


### PR DESCRIPTION
Casting brackets misplaced on TimeSec for displaying current uptime.
All variables for seconds changed to "unsigned"