### PR TITLE
Update platformio-example.ini with "min_spiffs.csv" option

### DIFF
--- a/platformio-example.ini
+++ b/platformio-example.ini
@@ -16,6 +16,7 @@ src_dir = multigeiger
 
 [env:geiger]
 board = heltec_wireless_stick
+board_build.partitions = min_spiffs.csv
 build_flags =
   -D CFG_eu868=1
   -D CFG_sx1276_radio=1


### PR DESCRIPTION
For old Heltec WiFiKit 32 with only 4MB. 
Minimum SPIFFS added for Platformio as described for Arduino IDE, in order to extend the flashable memory.